### PR TITLE
Allow the request to provide options to the FS lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ You can modify the `opts` variable as per your need under the `Tests` tab of the
 1. If you want all the data to be written to a single file then you can modify the value of mode to appendFile instead of writeFile (More functions here: [Node FS](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback))
 
 2. If you want each response to be stored in a different file, then you can provide a `uniqueIdentifier` such as `Date.now()` or some environment variable as a counter, and it'll be used generate unique file names. You can also make the value of uniqueIdentifier as `true` and the server will internally append a unique number to every file name.
+
+3. You can provide options to the FS lib, e.g. `options: { encoding: 'base64' }`.

--- a/script.js
+++ b/script.js
@@ -21,12 +21,13 @@ app.get('/', (req, res) => res.send('Hello, I write data to file. Send them requ
 
 app.post('/write', (req, res) => {
   let extension = req.body.fileExtension || defaultFileExtension,
-    fsMode = req.body.mode || DEFAULT_MODE;
+    fsMode = req.body.mode || DEFAULT_MODE,
     uniqueIdentifier = req.body.uniqueIdentifier ? typeof req.body.uniqueIdentifier === 'boolean' ? Date.now() : req.body.uniqueIdentifier : false,
     filename = `${req.body.requestName}${uniqueIdentifier || ''}`,
-    filePath = `${path.join(folderPath, filename)}.${extension}`;
+    filePath = `${path.join(folderPath, filename)}.${extension}`,
+    options = req.body.options || undefined;
 
-  fs[fsMode](filePath, req.body.responseData, (err) => {
+  fs[fsMode](filePath, req.body.responseData, options, (err) => {
     if (err) {
       console.log(err);
       res.send('Error');


### PR DESCRIPTION
When sending e.g. base64 payload, this is very helpful to automatically convert it to bytes when writing the file.